### PR TITLE
Potential fix for code scanning alert no. 70: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -16,6 +16,11 @@ module.exports = function profileImageUrlUpload () {
   return (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
+      const allowedHostnames = ['example.com', 'another-allowed-domain.com']
+      const hostname = new URL(url).hostname
+      if (!allowedHostnames.includes(hostname)) {
+        return res.status(400).send('Invalid image URL')
+      }
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/VDS-Test/juice-shop/security/code-scanning/70](https://github.com/VDS-Test/juice-shop/security/code-scanning/70)

To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a whitelist of allowed domains or subdomains. This will prevent attackers from using arbitrary URLs in the request. We can achieve this by extracting the hostname from the user-provided URL and checking it against a predefined list of allowed hostnames.

1. Extract the hostname from the user-provided URL.
2. Check if the hostname is in the list of allowed hostnames.
3. If the hostname is not allowed, return an error response.
4. If the hostname is allowed, proceed with the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
